### PR TITLE
Patch issue #8 for subclassing of Cucumber runner

### DIFF
--- a/src/main/java/org/pitest/cucumber/CucumberTestUnitFinder.java
+++ b/src/main/java/org/pitest/cucumber/CucumberTestUnitFinder.java
@@ -1,7 +1,14 @@
 package org.pitest.cucumber;
 
 
-import cucumber.api.CucumberOptions;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.runner.RunWith;
+import org.pitest.testapi.TestUnit;
+import org.pitest.testapi.TestUnitFinder;
+import org.pitest.util.Log;
+
 import cucumber.api.junit.Cucumber;
 import cucumber.runtime.RuntimeOptions;
 import cucumber.runtime.RuntimeOptionsFactory;
@@ -12,20 +19,13 @@ import cucumber.runtime.model.CucumberFeature;
 import cucumber.runtime.model.CucumberScenario;
 import cucumber.runtime.model.CucumberScenarioOutline;
 import cucumber.runtime.model.CucumberTagStatement;
-import org.junit.runner.RunWith;
-import org.pitest.testapi.TestUnit;
-import org.pitest.testapi.TestUnitFinder;
-import org.pitest.util.Log;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class CucumberTestUnitFinder implements TestUnitFinder {
 
     public List<TestUnit> findTestUnits(Class<?> junitTestClass) {
         List<TestUnit> result = new ArrayList<TestUnit>();
         RunWith annotation = junitTestClass.getAnnotation(RunWith.class);
-        if (annotation!= null && Cucumber.class.equals(annotation.value())) {
+        if (annotation!= null && Cucumber.class.isAssignableFrom(annotation.value())) {
             RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(junitTestClass);
             RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
             ClassLoader classLoader = junitTestClass.getClassLoader();

--- a/src/test/java/org/pitest/cucumber/CucumberTestUnitFinderTest.java
+++ b/src/test/java/org/pitest/cucumber/CucumberTestUnitFinderTest.java
@@ -1,22 +1,21 @@
 package org.pitest.cucumber;
 
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.model.InitializationError;
 import org.mockito.MockitoAnnotations;
 import org.pitest.testapi.Description;
-import org.pitest.testapi.ResultCollector;
 import org.pitest.testapi.TestUnit;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
 
 public class CucumberTestUnitFinderTest {
 
@@ -40,6 +39,20 @@ public class CucumberTestUnitFinderTest {
         Description description = testUnits.get(0).getDescription();
         assertThat(description.getFirstTestClass()).contains(HideFromJUnit.Cornichon.class.getSimpleName());
         assertThat(description.getName()).containsIgnoringCase("Shopping").containsIgnoringCase("change");
+    }
+    
+    @Test
+    public void should_find_one_test_unit_for_one_feature_available_in_classpath_using_subclassed_runner() throws Exception {
+    	// given cucumber features in the classpath
+    	
+    	// when
+    	List<TestUnit> testUnits = finder.findTestUnits(HideFromJUnit.Pepino.class);
+    	
+    	// then
+    	assertThat(testUnits).hasSize(1);
+    	Description description = testUnits.get(0).getDescription();
+    	assertThat(description.getFirstTestClass()).contains(HideFromJUnit.Pepino.class.getSimpleName());
+    	assertThat(description.getName()).containsIgnoringCase("Shopping").containsIgnoringCase("change");
     }
 
     @Test
@@ -75,6 +88,17 @@ public class CucumberTestUnitFinderTest {
         @RunWith(Cucumber.class)
         @CucumberOptions(features = "classpath:")
         private static class Concombre {
+        }
+        
+        @RunWith(Gurke.class)
+        @CucumberOptions(features = "classpath:cucumber/examples/java/calculator/shopping.feature")
+        private static class Pepino {
+        }
+        
+        private class Gurke extends Cucumber {
+			public Gurke(Class<?> clazz) throws InitializationError, IOException {
+				super(clazz);
+			}
         }
 
     }


### PR DESCRIPTION
Changed .equals to .isAssignableFrom in the CucumberTestUnitFinder for the purpose of working with all subclassed instances of the Cucumber test runner.  Also organized imports to remove and unused import.