### PR TITLE
updating pit version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 	<properties>
 		<junit.version>4.11</junit.version>
 		<cucumber.version>1.2.2</cucumber.version>
-		<pitest.version>1.1.0</pitest.version>
+		<pitest.version>1.1.4</pitest.version>
         <surefire.version>2.16</surefire.version>
 	</properties>
 


### PR DESCRIPTION
Due to the MetaData class being removed when Pit went from 1.1.2 to 1.1.3, the plugin was throwing an error at runtime for a missing class when running with the latest version of Pit.  Updating the version of Pit to 1.1.4 (latest) fixing the versioning issue for anyone attempting to run the plugin as part of a pit run using any version above 1.1.3.

I also submitted a pull request for issue #8 and you may want to create a release with just that request to add the subclassing functionality, but still work with older versions of Pit.  Then create another release with this pull to work with the latest version of Pit.  That way users can pull the version of the plugin needed for their version of Pit and still get the subclassing functionality either way.  Just my two cents.  I hope these pulls are helpful.