### PR TITLE
Upgrade dependencies to latest version of pitest (1.1.11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     </developers>
 
 	<properties>
-		<junit.version>4.11</junit.version>
+		<junit.version>4.12</junit.version>
 		<cucumber.version>1.2.2</cucumber.version>
 		<pitest.version>1.1.11</pitest.version>
         <surefire.version>2.16</surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 	<properties>
 		<junit.version>4.11</junit.version>
 		<cucumber.version>1.2.2</cucumber.version>
-		<pitest.version>1.1.10</pitest.version>
+		<pitest.version>1.1.11</pitest.version>
         <surefire.version>2.16</surefire.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 	<properties>
 		<junit.version>4.11</junit.version>
 		<cucumber.version>1.2.2</cucumber.version>
-		<pitest.version>1.1.4</pitest.version>
+		<pitest.version>1.1.10</pitest.version>
         <surefire.version>2.16</surefire.version>
 	</properties>
 

--- a/src/main/java/org/pitest/cucumber/CucumberJUnitCompatibleConfiguration.java
+++ b/src/main/java/org/pitest/cucumber/CucumberJUnitCompatibleConfiguration.java
@@ -7,6 +7,7 @@ import org.pitest.testapi.TestGroupConfig;
 import org.pitest.testapi.TestUnitFinder;
 import org.pitest.util.Log;
 
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -14,7 +15,7 @@ import static java.util.Arrays.asList;
 public class CucumberJUnitCompatibleConfiguration extends JUnitCompatibleConfiguration {
 
     public CucumberJUnitCompatibleConfiguration(TestGroupConfig config) {
-        super(config);
+        super(config, Collections.<String>emptyList());
     }
 
     @Override

--- a/src/main/java/org/pitest/cucumber/CucumberTestFrameworkPlugin.java
+++ b/src/main/java/org/pitest/cucumber/CucumberTestFrameworkPlugin.java
@@ -5,14 +5,17 @@ import org.pitest.testapi.Configuration;
 import org.pitest.testapi.TestGroupConfig;
 import org.pitest.testapi.TestPluginFactory;
 
-public class CucumberTestFrameworkPlugin  implements TestPluginFactory {
+import java.util.Collection;
+
+public class CucumberTestFrameworkPlugin implements TestPluginFactory {
 
     public String description() {
         return "Cucumber with JUnit support";
     }
 
     public Configuration createTestFrameworkConfiguration(TestGroupConfig config,
-                                                          ClassByteArraySource source) {
+                                                          ClassByteArraySource source,
+                                                          Collection<String> excludedRunners) {
 
         return new CucumberJUnitCompatibleConfiguration(config);
     }


### PR DESCRIPTION
Hello :)

I ran into issues when attempting to add this plugin to a project using pitest version 1.1.11, the build would crash with error messages on API mismatch.

I looked a bit into it and noticed that pitest-cucumber-plugin itself would fail to build if I upgraded the pitest dependency to the latest version with similar error messages. The build failed on compilation errors due to API changes in pitest. (See or https://github.com/hcoles/pitest/issues/170 or https://github.com/hcoles/pitest/pull/283 for more details)

I resolved these compilation errors by adding an additional parameter. I haven't done any extensive testing on this but the test suite is green and `mvn clean install` ran successfully.

Let me know if you have any questions or comments.