### PR TITLE
test: Upgrade to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,11 @@
     </developers>
 
     <properties>
-        <junit.version>4.12</junit.version>
+        <junit.version>5.5.1</junit.version>
         <cucumber.version>4.5.4</cucumber.version>
         <pitest.version>1.4.9</pitest.version>
-        <surefire.version>2.16</surefire.version>
+        <surefire.version>2.22.2</surefire.version>
+        <mockito.version>3.0.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -62,12 +63,6 @@
             <version>${pitest.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>compile</scope>
-        </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
@@ -81,14 +76,32 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>1.6.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -100,13 +113,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>${surefire.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <testNGArtifactName>none:none</testNGArtifactName>
                 </configuration>

--- a/src/test/java/org/pitest/cucumber/CucumberTestUnitFinderTest.java
+++ b/src/test/java/org/pitest/cucumber/CucumberTestUnitFinderTest.java
@@ -1,34 +1,30 @@
 package org.pitest.cucumber;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
 import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.InitializationError;
 import org.mockito.MockitoAnnotations;
 import org.pitest.testapi.Description;
 import org.pitest.testapi.TestUnit;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
-
-public class CucumberTestUnitFinderTest {
+class CucumberTestUnitFinderTest {
 
     private CucumberTestUnitFinder finder;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         MockitoAnnotations.initMocks(this);
         this.finder = new CucumberTestUnitFinder();
     }
 
     @Test
-    public void should_find_one_test_unit_for_one_feature_available_in_classpath() throws Exception {
+    void should_find_one_test_unit_for_one_feature_available_in_classpath() {
         // given cucumber features in the classpath
 
         // when
@@ -42,7 +38,7 @@ public class CucumberTestUnitFinderTest {
     }
 
     @Test
-    public void should_find_one_test_unit_for_one_feature_available_in_classpath_using_subclassed_runner() throws Exception {
+    void should_find_one_test_unit_for_one_feature_available_in_classpath_using_subclassed_runner() {
         // given cucumber features in the classpath
 
         // when
@@ -56,7 +52,7 @@ public class CucumberTestUnitFinderTest {
     }
 
     @Test
-    public void should_find_as_many_test_units_as_features_and_examples_available_in_classpath() throws Exception {
+    void should_find_as_many_test_units_as_features_and_examples_available_in_classpath() {
         // given cucumber features in the classpath
 
         // when
@@ -67,7 +63,7 @@ public class CucumberTestUnitFinderTest {
     }
 
     @Test
-    public void should_find_no_test_units_on_a_standard_junit_test() {
+    void should_find_no_test_units_on_a_standard_junit_test() {
         // given this very test class
 
         // when
@@ -96,7 +92,7 @@ public class CucumberTestUnitFinderTest {
         }
 
         private class Gurke extends Cucumber {
-            public Gurke(Class<?> clazz) throws InitializationError, IOException {
+            public Gurke(Class<?> clazz) throws InitializationError {
                 super(clazz);
             }
         }

--- a/src/test/java/org/pitest/cucumber/IntegrationTest.java
+++ b/src/test/java/org/pitest/cucumber/IntegrationTest.java
@@ -1,38 +1,38 @@
 package org.pitest.cucumber;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
-import cucumber.examples.java.calculator.Cornichon;
-import cucumber.examples.java.calculator.DateCalculator;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.pitest.testapi.Description;
-import org.pitest.testapi.ResultCollector;
-import org.pitest.testapi.TestUnit;
-
-import java.util.List;
-
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IntegrationTest {
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import cucumber.examples.java.calculator.Cornichon;
+import cucumber.examples.java.calculator.DateCalculator;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pitest.testapi.Description;
+import org.pitest.testapi.ResultCollector;
+import org.pitest.testapi.TestUnit;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationTest {
 
     @Mock
     private ResultCollector resultCollector;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() {
         DateCalculator.failMode.set(null);
     }
 
     @Test
-    public void should_run_scenarios_successfully() throws Exception {
+    void should_run_scenarios_successfully() {
         // given
         TestUnit firstTest = getScenarioTestUnit();
 
@@ -46,7 +46,7 @@ public class IntegrationTest {
     }
 
     @Test
-    public void should_detect_scenario_failure() throws Exception {
+    void should_detect_scenario_failure() {
         // given
         TestUnit firstTest = getScenarioTestUnit();
         DateCalculator.failMode.set(true);
@@ -61,7 +61,7 @@ public class IntegrationTest {
     }
 
     @Test
-    public void should_detect_skipped_scenario() throws Exception {
+    void should_detect_skipped_scenario() {
         // given
         CucumberTestUnitFinder finder = new CucumberTestUnitFinder();
         List<TestUnit> testUnits = finder.findTestUnits(HideFromJUnit.Cornichon.class);

--- a/src/test/java/org/pitest/cucumber/ScenarioTestUnitTest.java
+++ b/src/test/java/org/pitest/cucumber/ScenarioTestUnitTest.java
@@ -1,5 +1,11 @@
 package org.pitest.cucumber;
 
+import static java.util.Collections.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import cucumber.api.junit.Cucumber;
 import cucumber.runner.EventBus;
 import cucumber.runner.Runner;
@@ -7,17 +13,15 @@ import cucumber.runner.RunnerSupplier;
 import gherkin.events.PickleEvent;
 import gherkin.pickles.Pickle;
 import io.cucumber.core.options.RuntimeOptions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.pitest.testapi.Description;
 import org.pitest.testapi.ResultCollector;
 
-import static java.util.Collections.emptyList;
-import static org.mockito.Mockito.*;
-
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ScenarioTestUnitTest {
 
     Pickle pickle = new Pickle(null, null, emptyList(), null, emptyList());


### PR DESCRIPTION
Hi Alex,

I'm sorry, I missed important Cucumber changes in my previous PR.

Notably a compatibility issue using new annotations from io.cucumber.junit.* due to a missing refactoring which makes it bound to cucumber.api.CucumberOptions :

- https://github.com/cucumber/cucumber-jvm/blob/016558608ea5bbd6909c7d541ba1348ef4ff99eb/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java#L288

Thus,
in order to follow current Cucumber refactorings, I wanted to parameterized tests.
I choose to go with the JUnit5 feature instead of v4.12 or junitparams.

**This PR migrates JUnit from 4.12 to 5.5.1 only**

Next PR will provide compatibility using cucumber 4.5.4 up to 4.7.1 using both deprecated and new annotations.

If I have time, I will prepare Cucumber 5.0.0 support

Thanks again,

Mael