### PR TITLE
#27 Removed binding to specific version of PIT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.alexvictoor</groupId>
     <artifactId>pitest-cucumber-plugin</artifactId>
     <name>pitest-cucumber-plugin</name>
-    <version>0.8</version>
+    <version>0.9-SNAPSHOT</version>
     <url>https://github.com/alexvictoor/pitest-cucumber-plugin</url>
     <description>Cucumber PIT integration plugin</description>
 
@@ -60,23 +60,26 @@
             <groupId>org.pitest</groupId>
             <artifactId>pitest</artifactId>
             <version>${pitest.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
             <version>${cucumber.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
             <version>${cucumber.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- Removed binding to specific version of PIT by specifying pitest with the provided scope.
- Updated version to 0.9-SNAPSHOT
- I have also specified cucumber jars and the junit jar as provided as well.
- Tested against the cucumber-4.x.x-examples bundled with cucumber 4.x.x (4.8.2-SNAPSHOT at the time of this commit).  The Java Calculator TestNG example has classpath issues and the Spring Transactions example times out, but this was the case with version 0.8 of the pitest-cucumber-plugin as well.